### PR TITLE
Change Markdown engine and syntax highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,13 +54,13 @@ baseurl: ""
 # !! You don't need to change any of the configuration flags below !!
 #
 
-markdown: redcarpet
-highlighter: pygments
+markdown: kramdown
 permalink: /:title/
 markdown_ext:  markdown,mkdown,mkdn,mkd,md
 
-redcarpet:
-  extensions: ["tables", "autolink", "strikethrough", "space_after_headers", "with_toc_data", "fenced_code_blocks"]
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 
 # The release of Jekyll Now that you're using
 version: v1.1.0

--- a/_posts/2015-12-18-week-3-dec-2015-updates.md
+++ b/_posts/2015-12-18-week-3-dec-2015-updates.md
@@ -24,9 +24,9 @@ Hello, this is the first series of updates on software development that we hope 
 
 Here some interesting products or services we found this week:-
 
-1. List of VPS providers in Japan - https://romanrm.net/vps/japan.
-2. An easy way to build website - http://kedaiweb.site/.
-3. Another easy way to build website but this is a bit different, it build your website from your Facebook Page. Quite cool and practical idea I think - http://instaweb.my/.
+1. List of VPS providers in Japan - [https://romanrm.net/vps/japan](https://romanrm.net/vps/japan).
+2. An easy way to build website - [http://kedaiweb.site/](http://kedaiweb.site/).
+3. Another easy way to build website but this is a bit different, it build your website from your Facebook Page. Quite cool and practical idea I think - [http://instaweb.my/](http://instaweb.my/).
 4. Webfaction (disclosure: my favourite shared hosting) has added [support for PHP7](https://blog.webfaction.com/2015/12/php-7-is-here/) in it's hosting package.
 
 That's all for now. Until we meet again next week. Meanwhile, why not hop to our [Telegram Group](https://telegram.me/joinchat/ACIF0AHECE3dGeOPeqM8zw) for discussion ?

--- a/_posts/2015-12-19-bagaimana-aws-bermula.md
+++ b/_posts/2015-12-19-bagaimana-aws-bermula.md
@@ -27,6 +27,6 @@ Antara dapatan menarik daripada kisah ini adalah bagaimana Jeff Bezos memberi pe
 
 Sumber:-
 
-1. http://www.businessinsider.com/amazons-game-changing-cloud-was-built-by-some-guys-in-south-africa-2012-3
-2. http://www.businessinsider.my/benjamin-black-and-amazon-web-services-2014-7/
-3. http://blog.b3k.us/2009/01/25/ec2-origins.html
+1. [http://www.businessinsider.com/amazons-game-changing-cloud-was-built-by-some-guys-in-south-africa-2012-3](http://www.businessinsider.com/amazons-game-changing-cloud-was-built-by-some-guys-in-south-africa-2012-3)
+2. [http://www.businessinsider.my/benjamin-black-and-amazon-web-services-2014-7/](http://www.businessinsider.my/benjamin-black-and-amazon-web-services-2014-7/)
+3. [http://blog.b3k.us/2009/01/25/ec2-origins.html](http://blog.b3k.us/2009/01/25/ec2-origins.html)

--- a/_posts/2016-01-05-daily-git-commands.md
+++ b/_posts/2016-01-05-daily-git-commands.md
@@ -86,4 +86,5 @@ Discovered this today. I'm on a branch and there's some changes there that I wan
 
 So `git stash -p` is the equivalent of `git add -p` for stashing.
 
-Reference - http://stackoverflow.com/questions/3040833/stash-only-one-file-out-of-multiple-files-that-have-changed-with-git
+Reference -
+[http://stackoverflow.com/questions/3040833/stash-only-one-file-out-of-multiple-files-that-have-changed-with-git](http://stackoverflow.com/questions/3040833/stash-only-one-file-out-of-multiple-files-that-have-changed-with-git)

--- a/_posts/2016-01-05-daily-git-commands.md
+++ b/_posts/2016-01-05-daily-git-commands.md
@@ -51,7 +51,7 @@ If you are sure you want to delete it, run 'git branch -D 41-messages-too-long'.
 ```
 git log origin/master..master
 ```
-http://stackoverflow.com/questions/7624790/what-is-the-git-equivalent-of-of-hg-outgoing-hg-out-or-hg-incoming-hg-in
+[http://stackoverflow.com/questions/7624790/what-is-the-git-equivalent-of-of-hg-outgoing-hg-out-or-hg-incoming-hg-in](http://stackoverflow.com/questions/7624790/what-is-the-git-equivalent-of-of-hg-outgoing-hg-out-or-hg-incoming-hg-in)
 
 ### Git add patch
 `git add -p` I think is pretty well known but I've just discovered one of it's very handy option

--- a/_posts/2016-01-10-telegram-generasi-bot.md
+++ b/_posts/2016-01-10-telegram-generasi-bot.md
@@ -9,14 +9,14 @@ Ada 2 generasi bot. Generasi awal, yang seperti user biasa - perlukan phone numb
 
 Bot generasi baru menggunakan official [Bot API][api]. Nama dia mesti ada "bot" kat belakang. Tak perlukan phone number. Cuma boleh terima mesej yang dihantar khusus kepadanya - sama ada melalui command seperti `/cari`, `/help` atau pun kalau mention nama dia seperti `@kambingbot` dan sebagainya. Boleh terima semua mesej kalau privacy setting bot itu diubah.
 
-https://github.com/yagop/telegram-bot - bot generasi awal. Based on Lua so in theory boleh run kat windows.
+[https://github.com/yagop/telegram-bot](https://github.com/yagop/telegram-bot) - bot generasi awal. Based on Lua so in theory boleh run kat windows.
 
-https://github.com/yagop/telegram-bot - A Telegram Bot based on plugins
-https://github.com/yukuku/telebot - bot generasi baru, based on Python, run on app engine.
+[https://github.com/yagop/telegram-bot](https://github.com/yagop/telegram-bot) - A Telegram Bot based on plugins
+[https://github.com/yukuku/telebot](https://github.com/yukuku/telebot) - bot generasi baru, based on Python, run on app engine.
 
-https://gist.github.com/k4ml/04867dc17389a1cfba45 - also on python tapi just basic example.
+[https://gist.github.com/k4ml/04867dc17389a1cfba45](https://gist.github.com/k4ml/04867dc17389a1cfba45) - also on python tapi just basic example.
 
-Satu lagi library pilihan saya untuk develop bot adalah https://github.com/python-telegram-bot/python-telegram-bot. Menggunakan library ini, membina bot adalah semudah beberapa baris code seperti di bawah:-
+Satu lagi library pilihan saya untuk develop bot adalah [https://github.com/python-telegram-bot/python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot). Menggunakan library ini, membina bot adalah semudah beberapa baris code seperti di bawah:-
 
 ```python
 from telegram import Updater

--- a/_posts/2016-01-14-github-notes-lack-search.md
+++ b/_posts/2016-01-14-github-notes-lack-search.md
@@ -21,8 +21,8 @@ This [blog post](http://ariya.ofilabs.com/2012/08/github-and-lack-of-searchabili
 ## Triangular Workflow
 This work great so far except for a few hiccups but let's look at what it mean first. This diagram describe it well:-
 
-<img src="https://cloud.githubusercontent.com/assets/1319791/8943755/5dcdcae4-354a-11e5-9f82-915914fad4f7.png"></img>
-Image ref - https://github.com/blog/2042-git-2-5-including-multiple-worktrees-and-triangular-workflows
+<img src="https://cloud.githubusercontent.com/assets/1319791/8943755/5dcdcae4-354a-11e5-9f82-915914fad4f7.png" />
+Image ref - [https://github.com/blog/2042-git-2-5-including-multiple-worktrees-and-triangular-workflows](https://github.com/blog/2042-git-2-5-including-multiple-worktrees-and-triangular-workflows)
 
 Most of our repos only writable by a few developers, which the rest of the team will need to fork and submit their changes through a Pull Request. Few of the hiccups I mentioned just now:-
 

--- a/_posts/2016-01-28-git-merge-unrelated-repos.md
+++ b/_posts/2016-01-28-git-merge-unrelated-repos.md
@@ -34,4 +34,4 @@ version will be used.
 
 I'd first seen this being used in [Openshift example](https://github.com/openshift/django-example).
 
-Other merge tips from Orchestra project - http://read.cookbook.orchestraplatform.com/installation/sync.html.
+Other merge tips from Orchestra project - [http://read.cookbook.orchestraplatform.com/installation/sync.html](http://read.cookbook.orchestraplatform.com/installation/sync.html).


### PR DESCRIPTION
Based on https://git.io/vgYlB, GitHub will only support kramdown in the future. This will also remove pygments which is Python dependent.

I also need to update all the links which is not formatted in Markdown to make sure it'll be displayed as link.